### PR TITLE
feat: treat `safenode-features` input as list

### DIFF
--- a/example-inputs/launch_network.yml
+++ b/example-inputs/launch_network.yml
@@ -27,7 +27,9 @@ branch: experimental
 repo-owner: maidsafe
 chunk-size: 4194304 # We are currently using 4MB chunks.
 # Features to enable on `safenode`
-safenode-features: feature1,feature2
+safenode-features:
+  - feature1
+  - feature2
 
 #
 # Node counts

--- a/example-inputs/launch_network.yml
+++ b/example-inputs/launch_network.yml
@@ -9,6 +9,9 @@ rewards-address: 0x03B770D9cD32077cC0bF330c13C114a87643B124
 # Optional
 # Remove any you don't want to use.
 
+# Populate this if you want to link the deployment to a pull request.
+related-pr: 1234
+
 #
 # Binary versions
 #

--- a/runner/cmd.py
+++ b/runner/cmd.py
@@ -558,7 +558,7 @@ def list_deployments(show_details: bool = False) -> None:
                  bootstrap_node_vm_size, generic_node_vm_size, private_node_vm_size,
                  uploader_vm_size, evm_network_type, _, max_log_files,
                  max_archived_log_files, evm_data_payments_address, evm_payment_token_address,
-                 evm_rpc_url, triggered_at, run_id) = deployment
+                 evm_rpc_url, related_pr, triggered_at, run_id) = deployment
                 
                 timestamp = datetime.fromisoformat(triggered_at).strftime("%Y-%m-%d %H:%M:%S")
                 rprint(f"Name: [green]{name}[/green]")
@@ -571,6 +571,9 @@ def list_deployments(show_details: bool = False) -> None:
                 }.get(evm_network_type, evm_network_type)
                 print(f"EVM Type: {evm_type_display}")
                 print(f"Workflow run: https://github.com/{REPO_OWNER}/{REPO_NAME}/actions/runs/{run_id}")
+                if related_pr:
+                    print(f"Related PR: #{related_pr}")
+                    print(f"Link: https://github.com/{REPO_OWNER}/safe_network/pull/{related_pr}")
 
                 if autonomi_version:
                     print(f"===============")
@@ -620,20 +623,24 @@ def list_deployments(show_details: bool = False) -> None:
                     if evm_rpc_url:
                         print(f"RPC URL: {evm_rpc_url}")
 
+
                 print("-" * 61)
         else:
-            print(f"{'ID':<5} {'Name':<7} {'Deployed':<20} {'EVM Type':<15}")
-            print("-" * 66)
+            print(f"{'ID':<5} {'Name':<7} {'Deployed':<20} {'PR#':<15}")
+            print("-" * 61)
             
             for deployment in deployments:
                 id = deployment[0]
                 name = deployment[2]
-                evm_network_type = deployment[23]
                 triggered_at = deployment[-2]
                 run_id = deployment[-1]
-                
+                related_pr = deployment[-3]
+                if related_pr:
+                    related_pr = f"#{related_pr}"
+                else:
+                    related_pr = "-"
                 timestamp = datetime.fromisoformat(triggered_at).strftime("%Y-%m-%d %H:%M:%S")
-                rprint(f"{id:<5} [green]{name:<7}[/green] {timestamp:<20} {evm_network_type:<15}")
+                rprint(f"{id:<5} [green]{name:<7}[/green] {timestamp:<20} {related_pr:<15}")
                 print(f"  https://github.com/{REPO_OWNER}/{REPO_NAME}/actions/runs/{run_id}")
     except sqlite3.Error as e:
         print(f"Error: Failed to retrieve deployments: {e}")

--- a/runner/cmd.py
+++ b/runner/cmd.py
@@ -8,7 +8,14 @@ from typing import Dict
 import requests
 from rich import print as rprint
 
-from runner.db import list_workflow_runs, record_deployment, list_deployments as db_list_deployments, create_comparison as db_create_comparison, validate_comparison_deployment_ids
+from runner.db import (
+    create_comparison as db_create_comparison,
+    list_comparisons as db_list_comparisons,
+    list_deployments as db_list_deployments,
+    list_workflow_runs,
+    record_deployment,
+    validate_comparison_deployment_ids,
+)
 from runner.workflows import (
     DepositFundsWorkflow,
     DestroyNetworkWorkflow,
@@ -661,4 +668,27 @@ def create_comparison(test_id: int, ref_id: int, thread_link: str) -> None:
         sys.exit(1)
     except sqlite3.Error as e:
         print(f"Error: Failed to create comparison: {e}")
+        sys.exit(1)
+
+def list_comparisons() -> None:
+    """List all recorded comparisons."""
+    try:
+        comparisons = db_list_comparisons()
+        if not comparisons:
+            print("No comparisons found.")
+            return
+            
+        print("=" * 61)
+        print(" " * 18 + "C O M P A R I S O N S" + " " * 18)
+        print("=" * 61)
+        
+        print(f"{'ID':<5} {'TEST':<7} {'REF':<7} {'Thread':<20}")
+        print("-" * 61)
+        
+        for comparison in comparisons:
+            id, test_name, ref_name, thread_link = comparison
+            rprint(f"{id:<5} {test_name:<7} {ref_name:<7} {thread_link}")
+            
+    except sqlite3.Error as e:
+        print(f"Error: Failed to retrieve comparisons: {e}")
         sys.exit(1)

--- a/runner/db.py
+++ b/runner/db.py
@@ -57,6 +57,7 @@ def init_db() -> None:
                 evm_data_payments_address TEXT,
                 evm_payment_token_address TEXT,
                 evm_rpc_url TEXT,
+                related_pr INTEGER,
                 FOREIGN KEY (workflow_run_id) REFERENCES workflow_runs(id)
             )
         """)
@@ -150,9 +151,10 @@ def record_deployment(workflow_run_id: int, config: Dict[str, Any], defaults: Di
                 uploader_vm_count, bootstrap_node_vm_size, generic_node_vm_size,
                 private_node_vm_size, uploader_vm_size, evm_network_type,
                 rewards_address, max_log_files, max_archived_log_files,
-                evm_data_payments_address, evm_payment_token_address, evm_rpc_url
+                evm_data_payments_address, evm_payment_token_address, evm_rpc_url,
+                related_pr
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 workflow_run_id,
@@ -183,7 +185,8 @@ def record_deployment(workflow_run_id: int, config: Dict[str, Any], defaults: Di
                 config.get("max-archived-log-files"),
                 config.get("evm-data-payments-address"),
                 config.get("evm-payment-token-address"),
-                config.get("evm-rpc-url")
+                config.get("evm-rpc-url"),
+                config.get("related-pr")
             )
         )
         conn.commit()

--- a/runner/db.py
+++ b/runner/db.py
@@ -134,6 +134,11 @@ def record_deployment(workflow_run_id: int, config: Dict[str, Any], defaults: Di
     conn = sqlite3.connect(DB_PATH)
     try:
         cursor = conn.cursor()
+        
+        safenode_features = config.get("safenode-features")
+        if isinstance(safenode_features, list):
+            safenode_features = ",".join(safenode_features)
+            
         cursor.execute(
             """
             INSERT INTO deployments (
@@ -147,7 +152,7 @@ def record_deployment(workflow_run_id: int, config: Dict[str, Any], defaults: Di
                 rewards_address, max_log_files, max_archived_log_files,
                 evm_data_payments_address, evm_payment_token_address, evm_rpc_url
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 workflow_run_id,
@@ -158,7 +163,7 @@ def record_deployment(workflow_run_id: int, config: Dict[str, Any], defaults: Di
                 config.get("branch"),
                 config.get("repo-owner"),
                 config.get("chunk-size"),
-                ",".join(config["safenode-features"]) if config.get("safenode-features") else None,
+                safenode_features,
                 config.get("bootstrap-node-count", defaults["bootstrap_node_count"]),
                 config.get("generic-node-count", defaults["generic_node_count"]),
                 config.get("private-node-count", defaults["private_node_count"]),

--- a/runner/db.py
+++ b/runner/db.py
@@ -284,3 +284,30 @@ def validate_comparison_deployment_ids(test_id: int, ref_id: int) -> None:
             raise ValueError(f"One or both deployment IDs ({test_id}, {ref_id}) do not exist")
     finally:
         conn.close()
+
+def list_comparisons() -> list:
+    """
+    Retrieve all comparisons from the database, joined with deployment names.
+    
+    Returns:
+        List of tuples containing (test_name, ref_name, thread_link)
+    """
+    init_db()
+    
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("""
+            SELECT 
+                c.id,
+                test.name as test_name,
+                ref.name as ref_name,
+                c.thread_link
+            FROM comparisons c
+            JOIN deployments test ON c.test_id = test.id
+            JOIN deployments ref ON c.ref_id = ref.id
+            ORDER BY c.created_at ASC
+        """)
+        return cursor.fetchall()
+    finally:
+        conn.close()

--- a/runner/main.py
+++ b/runner/main.py
@@ -44,6 +44,28 @@ def main():
     )
     
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    comparisons_parser = subparsers.add_parser("comparisons", help="Manage deployment comparisons")
+    comparisons_subparsers = comparisons_parser.add_subparsers(dest="comparisons_command", help="Available comparison commands")
+    
+    new_comparison_parser = comparisons_subparsers.add_parser("new", help="Create a new comparison")
+    new_comparison_parser.add_argument(
+        "--test-id",
+        type=int,
+        required=True,
+        help="ID of the test deployment"
+    )
+    new_comparison_parser.add_argument(
+        "--ref-id",
+        type=int,
+        required=True,
+        help="ID of the reference deployment"
+    )
+    new_comparison_parser.add_argument(
+        "--thread-link",
+        required=True,
+        help="Link to the comparison thread"
+    )
     
     deployment_parser = subparsers.add_parser("deployment", help="Manage deployments")
     deployment_subparsers = deployment_parser.add_subparsers(dest="deployment_command", help="Available deployment commands")
@@ -226,7 +248,13 @@ def main():
             format='%(asctime)s - %(levelname)s - %(message)s'
         )
     
-    if args.command == "deployment":
+    if args.command == "comparisons":
+        if args.comparisons_command == "new":
+            cmd.create_comparison(args.test_id, args.ref_id, args.thread_link)
+        else:
+            comparisons_parser.print_help()
+            sys.exit(1)
+    elif args.command == "deployment":
         if args.deployment_command == "ls":
             cmd.list_deployments(show_details=args.details)
         else:

--- a/runner/main.py
+++ b/runner/main.py
@@ -67,6 +67,8 @@ def main():
         help="Link to the comparison thread"
     )
     
+    comparisons_ls_parser = comparisons_subparsers.add_parser("ls", help="List all comparisons")
+    
     deployment_parser = subparsers.add_parser("deployment", help="Manage deployments")
     deployment_subparsers = deployment_parser.add_subparsers(dest="deployment_command", help="Available deployment commands")
     
@@ -251,6 +253,8 @@ def main():
     if args.command == "comparisons":
         if args.comparisons_command == "new":
             cmd.create_comparison(args.test_id, args.ref_id, args.thread_link)
+        elif args.comparisons_command == "ls":
+            cmd.list_comparisons()
         else:
             comparisons_parser.print_help()
             sys.exit(1)

--- a/runner/workflows.py
+++ b/runner/workflows.py
@@ -477,7 +477,6 @@ class LaunchNetworkWorkflow(WorkflowRun):
             "public-rpc": "--public-rpc",
             "repo-owner": "--repo-owner",
             "rewards-address": "--rewards-address",
-            "safenode-features": "--safenode-features",
             "uploader-vm-size": "--uploader-vm-size"
         }
         
@@ -489,6 +488,14 @@ class LaunchNetworkWorkflow(WorkflowRun):
                         deploy_args.append(arg_name)
                 else:
                     deploy_args.append(f"{arg_name} {value}")
+
+        if "safenode-features" in self.config:
+            features = self.config["safenode-features"]
+            if isinstance(features, list):
+                features_str = ",".join(features)
+                deploy_args.append(f"--safenode-features {features_str}")
+            else:
+                deploy_args.append(f"--safenode-features {features}")
         
         if deploy_args:
             inputs["deploy-args"] = " ".join(deploy_args)


### PR DESCRIPTION
- edfec27 **feat: treat `safenode-features` input as list**

  This makes it easier to use than a comma-separated string.

- abcdc4d **feat: add a related pr field to deployments**

  This is very useful for tracking the deployment later.

- af66770 **feat: provide `comparisons new` command**

  I can now keep a history of comparisons in the database.

- 329426e **feat: provide `comparisons ls` cmd**

  It would be useful to provide more information in this view, but I don't have the time right now.