### PR TITLE
feat: use recent deploys for comparison selection

### DIFF
--- a/example-inputs/upscale_network.yml
+++ b/example-inputs/upscale_network.yml
@@ -14,6 +14,7 @@ repo-owner: maidsafe
 #
 # Binary versions
 #
+# The ant version will only be required for upscaling uploaders.
 ant-version: 0.1.0
 antnode-version: 0.1.0
 antctl-version: 0.1.0
@@ -44,6 +45,9 @@ plan: false
 # Interval to apply between starting each node, if nodes are being upscaled.
 # Units are milliseconds.
 interval: 10000
+
+# Required when upscaling uploaders.
+funding-wallet-secret-key: <your secret key>
 
 #
 # testnet-deploy options

--- a/runner/cmd/deployments.py
+++ b/runner/cmd/deployments.py
@@ -193,6 +193,7 @@ def smoke_test(deployment_id: int) -> None:
 
     questions = [
         "Are all nodes running?",
+        "Are the bootstrap cache files available?",
         "Is the main dashboard receiving data?",
         "Do nodes on generic hosts have open connections and connected peers?",
         "Do nodes on peer cache hosts have open connections and connected peers?",
@@ -201,7 +202,6 @@ def smoke_test(deployment_id: int) -> None:
         "Is `antctl` on the correct version?",
         "Is `antnode` on the correct version?",
         "Are the correct reserved IPs allocated?",
-        "Are the bootstrap cache files available?",
         "Is the uploader dashboard receiving data?",
         "Do uploader wallets have funds?",
         "Is `ant` on the correct version?",

--- a/runner/cmd/workflows.py
+++ b/runner/cmd/workflows.py
@@ -80,7 +80,7 @@ ENVIRONMENT_DEFAULTS = {
     }
 }
 
-def bootstrap_network(config: Dict, branch_name: str, force: bool = False) -> None:
+def bootstrap_network(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Bootstrap a new network."""
     _print_workflow_banner()
     
@@ -97,7 +97,7 @@ def bootstrap_network(config: Dict, branch_name: str, force: bool = False) -> No
     )
     
     try:
-        workflow_run_id = workflow.run(force=force)
+        workflow_run_id = workflow.run(force=force, wait=wait)
         env_type = config.get("environment-type", "development")
         defaults = ENVIRONMENT_DEFAULTS[env_type]
         repo = DeploymentRepository()
@@ -112,7 +112,7 @@ def bootstrap_network(config: Dict, branch_name: str, force: bool = False) -> No
         print(f"Error: Failed to trigger workflow: {e}")
         sys.exit(1)
 
-def deposit_funds(config: Dict, branch_name: str, force: bool = False) -> None:
+def deposit_funds(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Deposit funds to network nodes."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -136,9 +136,9 @@ def deposit_funds(config: Dict, branch_name: str, force: bool = False) -> None:
         tokens_to_transfer=config.get("tokens-to-transfer"),
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def destroy_network(config: Dict, branch_name: str, force: bool = False) -> None:
+def destroy_network(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     if "network-name" not in config:
         raise KeyError("network-name")
     
@@ -155,9 +155,9 @@ def destroy_network(config: Dict, branch_name: str, force: bool = False) -> None
         network_name=config["network-name"],
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def drain_funds(config: Dict, branch_name: str, force: bool = False) -> None:
+def drain_funds(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Drain funds from network nodes."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -176,9 +176,9 @@ def drain_funds(config: Dict, branch_name: str, force: bool = False) -> None:
         to_address=config.get("to-address"),
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def kill_droplets(config: Dict, branch_name: str, force: bool = False) -> None:
+def kill_droplets(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Kill specified droplets."""
     if "droplet-names" not in config:
         raise KeyError("droplet-names")
@@ -194,9 +194,9 @@ def kill_droplets(config: Dict, branch_name: str, force: bool = False) -> None:
         network_name=config["network-name"],
         droplet_names=config["droplet-names"]
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def launch_network(config: Dict, branch_name: str, force: bool = False) -> None:
+def launch_network(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Launch a new network."""
     _print_workflow_banner()
     
@@ -211,7 +211,7 @@ def launch_network(config: Dict, branch_name: str, force: bool = False) -> None:
     )
     
     try:
-        workflow_run_id = workflow.run(force=force)
+        workflow_run_id = workflow.run(force=force, wait=wait)
         env_type = config.get("environment-type", "development")
         defaults = ENVIRONMENT_DEFAULTS[env_type]
         repo = DeploymentRepository()
@@ -226,7 +226,7 @@ def launch_network(config: Dict, branch_name: str, force: bool = False) -> None:
         print(f"Error: Failed to trigger workflow: {e}")
         sys.exit(1)
 
-def launch_legacy_network(config: Dict, branch_name: str, force: bool = False) -> None:
+def launch_legacy_network(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Launch a new legacy network."""
     _print_workflow_banner()
     
@@ -241,7 +241,7 @@ def launch_legacy_network(config: Dict, branch_name: str, force: bool = False) -
     )
     
     try:
-        workflow_run_id = workflow.run(force=force)
+        workflow_run_id = workflow.run(force=force, wait=wait)
         env_type = config.get("environment-type", "development")
         defaults = ENVIRONMENT_DEFAULTS[env_type]
         
@@ -293,7 +293,7 @@ def ls(show_details: bool = False) -> None:
     
     print("\nAll times are in UTC")
 
-def network_status(config: Dict, branch_name: str, force: bool = False) -> None:
+def network_status(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Check status of nodes in a testnet network."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -312,10 +312,10 @@ def network_status(config: Dict, branch_name: str, force: bool = False) -> None:
         ansible_forks=config.get("ansible-forks"),
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
 
-def reset_to_n_nodes(config: Dict, branch_name: str, force: bool = False) -> None:
+def reset_to_n_nodes(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Reset network to run specified number of nodes."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -345,9 +345,9 @@ def reset_to_n_nodes(config: Dict, branch_name: str, force: bool = False) -> Non
         version=config.get("version"),
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def stop_nodes(config: Dict, branch_name: str, force: bool = False) -> None:
+def stop_nodes(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     if "network-name" not in config:
         raise KeyError("network-name")
     
@@ -369,9 +369,9 @@ def stop_nodes(config: Dict, branch_name: str, force: bool = False) -> None:
         node_type=NodeType(config["node-type"]) if "node-type" in config else None,
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def start_nodes(config: Dict, branch_name: str, force: bool = False) -> None:
+def start_nodes(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Start nodes in a testnet network."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -393,9 +393,9 @@ def start_nodes(config: Dict, branch_name: str, force: bool = False) -> None:
         node_type=NodeType(config["node-type"]) if "node-type" in config else None,
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def start_uploaders(config: Dict, branch_name: str, force: bool = False) -> None:
+def start_uploaders(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Start uploaders in a testnet network."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -413,9 +413,9 @@ def start_uploaders(config: Dict, branch_name: str, force: bool = False) -> None
         network_name=config["network-name"],
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def start_telegraf(config: Dict, branch_name: str, force: bool = False) -> None:
+def start_telegraf(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     if "network-name" not in config:
         raise KeyError("network-name")
     
@@ -436,9 +436,9 @@ def start_telegraf(config: Dict, branch_name: str, force: bool = False) -> None:
         node_type=NodeType(config["node-type"]) if "node-type" in config else None,
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def stop_telegraf(config: Dict, branch_name: str, force: bool = False) -> None:
+def stop_telegraf(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     if "network-name" not in config:
         raise KeyError("network-name")
     
@@ -459,9 +459,9 @@ def stop_telegraf(config: Dict, branch_name: str, force: bool = False) -> None:
         node_type=NodeType(config["node-type"]) if "node-type" in config else None,
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def stop_uploaders(config: Dict, branch_name: str, force: bool = False) -> None:
+def stop_uploaders(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Stop uploaders in a testnet network."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -479,9 +479,9 @@ def stop_uploaders(config: Dict, branch_name: str, force: bool = False) -> None:
         network_name=config["network-name"],
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def upgrade_antctl(config: Dict, branch_name: str, force: bool = False) -> None:
+def upgrade_antctl(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Upgrade antctl version."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -504,9 +504,9 @@ def upgrade_antctl(config: Dict, branch_name: str, force: bool = False) -> None:
         node_type=NodeType(config["node-type"]) if "node-type" in config else None,
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def upgrade_network(config: Dict, branch_name: str, force: bool = False) -> None:
+def upgrade_network(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Trigger the upgrade network workflow."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -532,9 +532,9 @@ def upgrade_network(config: Dict, branch_name: str, force: bool = False) -> None
         node_type=NodeType(config["node-type"]) if "node-type" in config else None,
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def update_peer(config: Dict, branch_name: str, force: bool = False) -> None:
+def update_peer(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Trigger the update peer workflow."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -554,9 +554,9 @@ def update_peer(config: Dict, branch_name: str, force: bool = False) -> None:
         custom_inventory=config.get("custom-inventory"),
         node_type=NodeType(config["node-type"]) if "node-type" in config else None
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def upgrade_uploaders(config: Dict, branch_name: str, force: bool = False) -> None:
+def upgrade_uploaders(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Trigger the upgrade uploaders workflow."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -577,9 +577,9 @@ def upgrade_uploaders(config: Dict, branch_name: str, force: bool = False) -> No
         version=config["version"],
         testnet_deploy_args=testnet_deploy_args
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def upscale_network(config: Dict, branch_name: str, force: bool = False) -> None:
+def upscale_network(config: Dict, branch_name: str, force: bool = False, wait: bool = False) -> None:
     """Upscale an existing network."""
     if "network-name" not in config:
         raise KeyError("network-name")
@@ -595,18 +595,19 @@ def upscale_network(config: Dict, branch_name: str, force: bool = False) -> None
         network_name=config["network-name"],
         config=config
     )
-    _execute_workflow(workflow, force)
+    _execute_workflow(workflow, force, wait)
 
-def _execute_workflow(workflow, force: bool = False) -> None:
+def _execute_workflow(workflow, force: bool = False, wait: bool = False) -> None:
     """
     Common function to execute a workflow and handle its output and errors.
     
     Args:
         workflow: The workflow instance to execute
         force: If True, skip confirmation prompt
+        wait: If True, wait for workflow completion
     """
     try:
-        workflow.run(force=force)
+        workflow.run(force=force, wait=wait)
         print("Workflow was dispatched with the following inputs:")
         for key, value in workflow.get_workflow_inputs().items():
             print(f"  {key}: {value}")

--- a/runner/main.py
+++ b/runner/main.py
@@ -425,7 +425,7 @@ def main():
         elif args.comparisons_command == "post":
             comparisons.post(args.id)
         elif args.comparisons_command == "print":
-            comparisons.print(args.id)
+            comparisons.print_comparison(args.id)
         elif args.comparisons_command == "record-results":
             comparisons.record_results(args.id, args.start, args.end, args.path, args.passed)
         else:

--- a/runner/main.py
+++ b/runner/main.py
@@ -158,6 +158,11 @@ def main():
 
 
     workflows_parser = subparsers.add_parser("workflows", help="Manage network workflows")
+    workflows_parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait for the workflow run to complete"
+    )
     workflows_subparsers = workflows_parser.add_subparsers(dest="workflows_command", help="Available workflow commands")
 
     bootstrap_network_parser = workflows_subparsers.add_parser("bootstrap-network", help="Bootstrap a new network")
@@ -446,66 +451,66 @@ def main():
     elif args.command == "workflows":
         if args.workflows_command == "bootstrap-network":
             config = load_yaml_config(args.path)
-            workflows.bootstrap_network(config, args.branch, args.force)
+            workflows.bootstrap_network(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "deposit-funds":
             config = load_yaml_config(args.path)
-            workflows.deposit_funds(config, args.branch, args.force)
+            workflows.deposit_funds(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "destroy-network":
             config = load_yaml_config(args.path)
-            workflows.destroy_network(config, args.branch, args.force)
+            workflows.destroy_network(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "drain-funds":
             config = load_yaml_config(args.path)
-            workflows.drain_funds(config, args.branch, args.force)
+            workflows.drain_funds(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "kill-droplets":
             config = load_yaml_config(args.path)
-            workflows.kill_droplets(config, args.branch, args.force)
+            workflows.kill_droplets(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "launch-legacy-network":
             config = load_yaml_config(args.path)
-            workflows.launch_legacy_network(config, "main", args.force)
+            workflows.launch_legacy_network(config, "main", args.force, args.wait)
         elif args.workflows_command == "launch-network":
             config = load_yaml_config(args.path)
-            workflows.launch_network(config, args.branch, args.force)
+            workflows.launch_network(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "ls":
             workflows.ls(show_details=args.details)
         elif args.workflows_command == "network-status":
             config = load_yaml_config(args.path)
-            workflows.network_status(config, args.branch, args.force)
+            workflows.network_status(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "start-nodes":
             config = load_yaml_config(args.path)
-            workflows.start_nodes(config, args.branch, args.force)
+            workflows.start_nodes(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "start-telegraf":
             config = load_yaml_config(args.path)
-            workflows.start_telegraf(config, args.branch, args.force)
+            workflows.start_telegraf(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "start-uploaders":
             config = load_yaml_config(args.path)
-            workflows.start_uploaders(config, args.branch, args.force)
+            workflows.start_uploaders(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "stop-nodes":
             config = load_yaml_config(args.path)
-            workflows.stop_nodes(config, args.branch, args.force)
+            workflows.stop_nodes(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "stop-telegraf":
             config = load_yaml_config(args.path)
-            workflows.stop_telegraf(config, args.branch, args.force)
+            workflows.stop_telegraf(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "stop-uploaders":
             config = load_yaml_config(args.path)
-            workflows.stop_uploaders(config, args.branch, args.force)
+            workflows.stop_uploaders(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "update-peer":
             config = load_yaml_config(args.path)
-            workflows.update_peer(config, args.branch, args.force)
+            workflows.update_peer(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "upgrade-antctl":
             config = load_yaml_config(args.path)
-            workflows.upgrade_antctl(config, args.branch, args.force)
+            workflows.upgrade_antctl(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "upgrade-network":
             config = load_yaml_config(args.path)
-            workflows.upgrade_network(config, args.branch, args.force)
+            workflows.upgrade_network(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "upgrade-uploaders":
             config = load_yaml_config(args.path)
-            workflows.upgrade_uploaders(config, args.branch, args.force)
+            workflows.upgrade_uploaders(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "upscale-network":
             config = load_yaml_config(args.path)
-            workflows.upscale_network(config, args.branch, args.force)
+            workflows.upscale_network(config, args.branch, args.force, args.wait)
         elif args.workflows_command == "reset-to-n-nodes":
             config = load_yaml_config(args.path)
-            workflows.reset_to_n_nodes(config, args.branch, args.force)
+            workflows.reset_to_n_nodes(config, args.branch, args.force, args.wait)
         else:
             workflows_parser.print_help()
             sys.exit(1)

--- a/runner/models.py
+++ b/runner/models.py
@@ -104,3 +104,9 @@ class SmokeTestResult(Base):
     created_at = Column(DateTime, nullable=False)
 
     deployment = relationship("Deployment", backref="smoke_test_results")
+
+@dataclass
+class RecentDeployment:
+    id: int
+    name: str
+    created_at: datetime


### PR DESCRIPTION
- b4e1276 **feat: use recent deploys for comparison selection**

  This is easier than providing the ID numbers.

- 83f158f **chore: ask bootstrap cache question sooner**

  With the network status running as part of the launch, it makes sense for this question to be asked
  sooner. From within the same workflow log I can check the bootstrap files just after I check if all
  the nodes are running.

- 821ed3b **feat: provide `--wait` flag for workflow runs**

  If the flag is used, the command will wait for the workflow to complete before exiting.

  This will be useful as a basic mechanism for doing unattended upscaling runs.

- ed71ea9 **chore: add funding key to upscaling example inputs**