### PR TITLE
fix: continue smoke test on failed item

### DIFF
--- a/runner/cmd/client_deployments.py
+++ b/runner/cmd/client_deployments.py
@@ -151,11 +151,11 @@ def smoke_test(deployment_id: int) -> None:
         results[question] = answer
         
         if answer == "No":
-            should_continue = questionary.confirm("Abandon the test?").ask()
+            should_continue = questionary.confirm("Continue the test?").ask()
             if not should_continue:
                 for remaining_question in questions[questions.index(question) + 1:]:
                     results[remaining_question] = "N/A"
-            break
+                break
 
     repo.record_smoke_test_result(deployment_id, results)
     print("\nRecorded results")

--- a/runner/cmd/deployments.py
+++ b/runner/cmd/deployments.py
@@ -269,11 +269,11 @@ def smoke_test(deployment_id: int) -> None:
         results[question] = answer
         
         if answer == "No":
-            should_continue = questionary.confirm("Abandon the test?").ask()
+            should_continue = questionary.confirm("Continue the test?").ask()
             if not should_continue:
                 for remaining_question in questions[questions.index(question) + 1:]:
                     results[remaining_question] = "N/A"
-            break
+                break
 
     repo.record_smoke_test_result(deployment_id, results)
     print("\nRecorded results")


### PR DESCRIPTION
This is the way it behaved before it was changed by the AI to mark the remaining items with "N/A" answers in the case of one item in the test failing.

We actually want the option to be able to progress with the remainder of the test.