### PR TITLE
feat: support `--upload-interval` arguments

### DIFF
--- a/example-inputs/client_deploy.yml
+++ b/example-inputs/client_deploy.yml
@@ -49,6 +49,9 @@ client-vm-count: 2
 client-vm-size: s-4vcpu-8gb
 # The number of uploader services on each client VM.
 uploaders-count: 1
+# Upload interval in seconds. Use a longer interval if you have a small network you don't want to
+# fill up quickly.
+upload-interval: 10
 
 # Miscellaneous options
 # Environment variables to set for the `ant` binary on the client VMs.

--- a/example-inputs/launch_network.yml
+++ b/example-inputs/launch_network.yml
@@ -115,6 +115,9 @@ max-archived-log-files: 1
 max-log-files: 1
 # Environment variables to set for `antnode` services.
 node-env: LOG_LEVEL=debug,RUST_LOG=info
+# Upload interval in seconds. Use a longer interval if you have a small network you don't want to
+# fill up quickly.
+upload-interval: 10
 
 #
 # EVM options

--- a/runner/workflows.py
+++ b/runner/workflows.py
@@ -664,6 +664,7 @@ class LaunchNetworkWorkflow(WorkflowRun):
             "region": "--region",
             "repo-owner": "--repo-owner",
             "rewards-address": "--rewards-address",
+            "upload-interval": "--upload-interval",
         }
         
         for config_key, arg_name in deploy_arg_mappings.items():
@@ -777,6 +778,7 @@ class ClientDeployWorkflow(WorkflowRun):
             "region": "--region",
             "repo-owner": "--repo-owner",
             "uploaders-count": "--uploaders-count",
+            "upload-interval": "--upload-interval",
             "upload-size": "--upload-size"
         }
         


### PR DESCRIPTION
This now applies to the `deploy` and `client deploy` commands to enable variance on the interval between uploads. It can be useful if you have a smaller deployment you don't want to fill up quickly.